### PR TITLE
correct build.sh and comment copy to tftboot inthe rt5572

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,21 +1,22 @@
-ARCH=arm
-PWD=`pwd`
+# !!! standalone not worked, call from sdk make !!!
 KSRC=$DEVDIR/kernel
-EXTRA_CFLAGS="-DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_TI_DM365 -I$PWD/include"
+EXTRA_CFLAGS="-DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_TI_DM365 -I$KSRC/include"
 
-export DEVDIR
+if [ -z "${CROSS_COMPILE}" ];
+then echo CROSS_COMPILE is not set - use make driversbuild
+exit 1
+fi
+
+export ARCH
 export CROSS_COMPILE
+export DEVDIR
 export KSRC
 export EXTRA_CFLAGS
-export ARCH
 
-for path in `ls`
+SUBDIRS="rt5572 rtl8188eu rtl8192cu rtl8192su"
+
+for path in ${SUBDIRS}
 do
-
-if [ "$path" = "build.sh" ] ;
-then
-	continue
-fi
 
 if [ "$1" = "BUILD" ] ;
 then
@@ -28,3 +29,4 @@ then
 fi
 
 done
+

--- a/rt5572/Makefile
+++ b/rt5572/Makefile
@@ -372,27 +372,27 @@ ifeq ($(OSABL),YES)
 endif
 
 ifeq ($(RT28xx_MODE),AP)
-	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)ap.o /tftpboot
-ifeq ($(OSABL),YES)
-	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)ap.o /tftpboot
-	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)ap.o /tftpboot
-endif
+#	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)ap.o /tftpboot
+#ifeq ($(OSABL),YES)
+#	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)ap.o /tftpboot
+#	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)ap.o /tftpboot
+#endif
 ifeq ($(PLATFORM),INF_AMAZON_SE)
 	cp -f /tftpboot/rt2870ap.o /backup/ifx/build/root_filesystem/lib/modules/2.4.31-Amazon_SE-3.6.2.2-R0416_Ralink/kernel/drivers/net
 endif
 else	
 ifeq ($(RT28xx_MODE),APSTA)
-	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)apsta.o /tftpboot
-ifeq ($(OSABL),YES)
-	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)apsta.o /tftpboot
-	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)apsta.o /tftpboot
-endif
+#	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)apsta.o /tftpboot
+#ifeq ($(OSABL),YES)
+#	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)apsta.o /tftpboot
+#	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)apsta.o /tftpboot
+#endif
 else
-	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)sta.o /tftpboot
-ifeq ($(OSABL),YES)
-	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)sta.o /tftpboot
-	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)sta.o /tftpboot
-endif
+#	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)sta.o /tftpboot
+#ifeq ($(OSABL),YES)
+#	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)sta.o /tftpboot
+#	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)sta.o /tftpboot
+#endif
 endif	
 endif	
 else
@@ -419,26 +419,26 @@ ifeq ($(OSABL),YES)
 endif
 
 ifeq ($(RT28xx_MODE),AP)
-	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)ap.ko /tftpboot
-ifeq ($(OSABL),YES)
-	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)ap.ko /tftpboot
-	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)ap.ko /tftpboot
-endif
+#	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)ap.ko /tftpboot
+#ifeq ($(OSABL),YES)
+#	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)ap.ko /tftpboot
+#	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)ap.ko /tftpboot
+#endif
 	rm -f os/linux/rt$(MODULE)ap.ko.lzma
 	/root/bin/lzma e os/linux/rt$(MODULE)ap.ko os/linux/rt$(MODULE)ap.ko.lzma
 else	
 ifeq ($(RT28xx_MODE),APSTA)
-	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)apsta.ko /tftpboot
-ifeq ($(OSABL),YES)
-	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)apsta.ko /tftpboot
-	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)apsta.ko /tftpboot
-endif
+#	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)apsta.ko /tftpboot
+#ifeq ($(OSABL),YES)
+#	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)apsta.ko /tftpboot
+#	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)apsta.ko /tftpboot
+#endif
 else
-	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)sta.ko /tftpboot
-ifeq ($(OSABL),YES)
-	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)sta.ko /tftpboot
-	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)sta.ko /tftpboot
-endif
+#	cp -f $(RT28xx_DIR)/os/linux/rt$(MODULE)sta.ko /tftpboot
+#ifeq ($(OSABL),YES)
+#	cp -f $(RT28xx_DIR)/os/linux/rtutil$(MODULE)sta.ko /tftpboot
+#	cp -f $(RT28xx_DIR)/os/linux/rtnet$(MODULE)sta.ko /tftpboot
+#endif
 endif
 endif
 endif


### PR DESCRIPTION
Changes in the build.sh - for working with extern variables sanded from sdk make.

Comment copy to /tftboot in the rt5572. 
