### PR TITLE
remove rtl8192su from SUBDIR list - not compilled correctly for kernel 3.9

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ export DEVDIR
 export KSRC
 export EXTRA_CFLAGS
 
-SUBDIRS="rt5572 rtl8188eu rtl8192cu rtl8192su"
+SUBDIRS="rt5572 rtl8188eu rtl8192cu"
 
 for path in ${SUBDIRS}
 do


### PR DESCRIPTION
Problem compiling this driver:
first:

```
Standalone drivers build for Virt2real SDK

arm /opt/virt2real-sdk/codesourcery/arm-2013.05/bin/arm-none-linux-gnueabi-
make[1]: Entering directory `/opt/virt2real-sdk/drivers/rtl8192su'
make ARCH=arm CROSS_COMPILE=/opt/virt2real-sdk/codesourcery/arm-2013.05/bin/arm-none-linux-gnueabi- -C /opt/virt2real-sdk/kernel M=/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi CONFIG_RTL_CARDS=y CONFIG_RTLWIFI=m CONFIG_RTLWIFI_DEBUG=y CONFIG_RTLWIFI_DEBUGFS=y CONFIG_RTLWIFI_USB=m CONFIG_RTLWIFI_PCI=n CONFIG_RTL8192SU=m CONFIG_RTL8192SE=m CONFIG_RTL8192S_COMMON=m CONFIG_RTL8192CU=n CONFIG_RTL8192DE=n CONFIG_RTL8192CE=n CONFIG_RTL8192C_COMMON=n CONFIG_RTL8723AE=n CONFIG_RTL8188EE=n  EXTRA_CFLAGS="-DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_TI_DM365 -I/opt/virt2real-sdk/kernel/include -DDEBUG -DCONFIG_RTLWIFI_DEBUGFS=m -Wimplicit-function-declaration"
make[2]: Entering directory `/opt/virt2real-sdk/kernel'
  CC [M]  /opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/cam.o
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/cam.c: In function 'rtl_cam_get_free_entry':
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/cam.c:298:3: error: implicit declaration of function 'ether_addr_equal_unaligned' [-Werror=implicit-function-declaration]
cc1: some warnings being treated as errors
make[3]: *** [/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/cam.o] Error 1
make[2]: *** [_module_/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi] Error 2
make[2]: Leaving directory `/opt/virt2real-sdk/kernel'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/opt/virt2real-sdk/drivers/rtl8192su'
```

Kernel changen need backport for ether_addr_equal_unaligned function. Apply backport from http://www.spinics.net/lists/backports/msg02246.html.

After this chanes, other error:

```
make[2]: Entering directory `/opt/virt2real-sdk/kernel'
  CC [M]  /opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/base.o
  CC [M]  /opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/cam.o
  CC [M]  /opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.o
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.c: In function 'rtl_op_config':
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.c:451:47: error: 'struct ieee80211_conf' has no member named 'chandef'
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.c:473:46: error: 'struct ieee80211_conf' has no member named 'chandef'
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.c:531:40: error: 'struct ieee80211_conf' has no member named 'chandef'
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.c: At top level:
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.c:1443:2: warning: initialization from incompatible pointer type [enabled by default]
/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.c:1443:2: warning: (near initialization for 'rtl_ops.flush') [enabled by default]
make[3]: *** [/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi/core.o] Error 1
make[2]: *** [_module_/opt/virt2real-sdk/drivers/rtl8192su/rtlwifi] Error 2
```
