### PR TITLE
install with -m 664

### DIFF
--- a/rt5572/copy.sh
+++ b/rt5572/copy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-install ./os/linux/rt5572sta.ko $TARGETDIR/lib/modules/$KERNEL_NAME/kernel/drivers/net/wireless
-install ./*.dat $TARGETDIR/etc/Wireless/RT2870STA/
+install -m 664 ./os/linux/rt5572sta.ko $TARGETDIR/lib/modules/$KERNEL_NAME/kernel/drivers/net/wireless
+install -m 664 ./*.dat $TARGETDIR/etc/Wireless/RT2870STA/

--- a/rtl8188eu/copy.sh
+++ b/rtl8188eu/copy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-install ./8188eu.ko $TARGETDIR/lib/modules/$KERNEL_NAME/kernel/drivers/net/wireless
-install ./rtl8188eufw.bin $TARGETDIR/lib/firmware/rtlwifi/
+install -m 664 ./8188eu.ko $TARGETDIR/lib/modules/$KERNEL_NAME/kernel/drivers/net/wireless
+install -m 664 ./rtl8188eufw.bin $TARGETDIR/lib/firmware/rtlwifi/

--- a/rtl8192cu/copy.sh
+++ b/rtl8192cu/copy.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-install ./8192cu.ko $TARGETDIR/lib/modules/$KERNEL_NAME/kernel/drivers/net/wireless
+install -m 664 ./8192cu.ko $TARGETDIR/lib/modules/$KERNEL_NAME/kernel/drivers/net/wireless
 mkdir -p $TARGETDIR/etc/modprobe.d
-install ./8192cu-disable-power-management.conf $TARGETDIR/etc/modprobe.d
-install ./blacklist-native-rtl8192.conf $TARGETDIR/etc/modprobe.d
+install -m 664 ./8192cu-disable-power-management.conf $TARGETDIR/etc/modprobe.d
+install -m 664 ./blacklist-native-rtl8192.conf $TARGETDIR/etc/modprobe.d


### PR DESCRIPTION
For postbuild right processing buildroot fs - kernel modules must not be executable.
